### PR TITLE
Add extra safety check for actions

### DIFF
--- a/SpeldesignBotCore/Modules/Minecraft/MinecraftServerDataProvider.cs
+++ b/SpeldesignBotCore/Modules/Minecraft/MinecraftServerDataProvider.cs
@@ -75,7 +75,7 @@ namespace SpeldesignBotCore.Modules.Minecraft
             // Not super clean, I'm sure there's a better way to do this
             var players = await GetMinecraftPlayersAsync();
             players = players
-                .Where(x => x.Stats[actionName][itemName] != null)
+                .Where(x => x.Stats[actionName] != null && x.Stats[actionName][itemName] != null)
                 .OrderByDescending(x => (int) x.Stats[actionName][itemName])
                 .Take(playersToReturnAmount)
                 .ToArray();


### PR DESCRIPTION
If a user had never dropped an item, the application would throw an error while trying to get statistics for dropped items.